### PR TITLE
Proctitle space encode correction Added

### DIFF
--- a/TA-linux_auditd/default/props.conf
+++ b/TA-linux_auditd/default/props.conf
@@ -61,7 +61,7 @@ EVAL-event_result = coalesce(res,success,result,avc_result,"unknown")
 EVAL-src = if(hostname="?",addr,hostname)
 EVAL-keystrokes = urldecode(replace(data,"([0-9A-F]{2})","%\1"))
 EVAL-command = if(match(cmd,"^[0-9A-F]+$"),urldecode(replace(cmd,"([0-9A-F]{2})","%\1")),coalesce(cmd,exe,comm))
-EVAL-process_name = urldecode(replace(proctitle,"([0-9A-F]{2})","%\1"))
+EVAL-process_name = urldecode(replace(replace(proctitle,"([0-9A-F]{2})","%\1"),"%00","%20"))
 
 [linux:audit:enriched]
 SEDCMD-convert_group_separator = s/\x1d/ /
@@ -108,5 +108,5 @@ EVAL-event_result = coalesce(res,success,result,avc_result,"unknown")
 EVAL-src = if(hostname="?",addr,hostname)
 EVAL-keystrokes = urldecode(replace(data,"([0-9A-F]{2})","%\1"))
 EVAL-command = if(match(cmd,"^[0-9A-F]+$"),urldecode(replace(cmd,"([0-9A-F]{2})","%\1")),coalesce(cmd,exe,comm))
-EVAL-process_name = urldecode(replace(proctitle,"([0-9A-F]{2})","%\1"))
+EVAL-process_name = urldecode(replace(replace(proctitle,"([0-9A-F]{2})","%\1"),"%00","%20"))
 EVAL-user = if(AUID=="unset","unknown",AUID)


### PR DESCRIPTION
Auditd encodes space as %00 (null) instead of %20. I propose the following change for a correct decoding of process_name .